### PR TITLE
fix: correct gemini api usage

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,7 @@
     "store_profile_after_training": false,
     "base_domain": "https://example.org"
   },
-  "general_setting": {
+  "general_settings": {
     "info": "Possible classifiers: SVM, NAIVE_BAYES, KNN, J48, MISTRAL, MLP, DEEP, BATCHNORM, Phase: LABELING, EXTRACTION, PROCESSING, TRAINING, STORE",
     "start_phase": "labeling",
     "stop_phase": "training"

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
   },
   "profile": {
     "store_profile_after_training": false,
-    "base_domain": "https://exemple.org"
+    "base_domain": "https://example.org"
   },
   "general_setting": {
     "info": "Possible classifiers: SVM, NAIVE_BAYES, KNN, J48, MISTRAL, MLP, DEEP, BATCHNORM, Phase: LABELING, EXTRACTION, PROCESSING, TRAINING, STORE",

--- a/config.py
+++ b/config.py
@@ -108,8 +108,8 @@ class Config:
         Config.STORE_PROFILE_AT_RUN = bool(config["profile"].get("store_profile_at_run", False))
         Config.BASE_DOMAIN = config["profile"].get("base_domain", "https://exemple.org")
 
-        Config.START_PHASE = _assign_enum_phase(config["general_setting"].get("start_phase", "NO"))
-        Config.STOP_PHASE = _assign_enum_phase(config["general_setting"].get("stop_phase", "NO"))
+        Config.START_PHASE = _assign_enum_phase(config["general_settings"].get("start_phase", "NO"))
+        Config.STOP_PHASE = _assign_enum_phase(config["general_settings"].get("stop_phase", "NO"))
         _check_phase_order(Config.START_PHASE, Config.STOP_PHASE)
         Config.ALLOWED_PHASE = _phase_list(phase=Config.START_PHASE, phase_2=Config.STOP_PHASE)
 

--- a/src/pipeline_gemma.py
+++ b/src/pipeline_gemma.py
@@ -155,7 +155,7 @@ class OllamaGemmaPredictor:
 
 
 class GeminiPredictor:
-    def __init__(self, temperature=0.0, model="models/gemini-2.0-flash", max_retries=5, initial_wait=10):
+    def __init__(self, temperature=0.0, model="models/gemini-2.5-flash", max_retries=5, initial_wait=10):
         self.temperature = temperature
         self.model = model
         self.key = os.environ.get("GEMINI_API_KEY")
@@ -291,11 +291,6 @@ class GeminiPredictor:
         logging.info(f"Gemini final precision: {precision:.4f}")
         logging.info(f"Gemini final recall:    {recall:.4f}")
         logging.info(f"Gemini final f1_score:  {f1:.4f}")
-        print(f"\nGemini final metrics (from predict_frame):")
-        print(f"  Accuracy : {acc:.4f}")
-        print(f"  Precision: {precision:.4f}")
-        print(f"  Recall   : {recall:.4f}")
-        print(f"  F1       : {f1:.4f}\n")
 
         return frame
 
@@ -317,7 +312,7 @@ if __name__ == "__main__":
         system_message_internal=system_message
     )
 
-    # # Gemini 2 Flash
+    # Gemini 2 Flash
     # gemini_predictor = GeminiPredictor(
     #     temperature=0.2,
     #     model="models/gemini-2.0-flash"
@@ -326,6 +321,6 @@ if __name__ == "__main__":
     #     df,
     #     content_column="comments",
     #     category_column="category",
-    #     system_message=system_message
+    #     system_message_internal=system_message
     # )
     # print(df_with_gemini_preds)


### PR DESCRIPTION
This pull request updates configuration and code related to the Gemini predictor and logging in the pipeline. The most significant changes are the upgrade to the Gemini model version, improvements to logging, and a correction in the configuration file.

Model and configuration updates:
* Upgraded the Gemini predictor to use `models/gemini-2.5-flash` instead of `models/gemini-2.0-flash` in the `GeminiPredictor` class constructor (`src/pipeline_gemma.py`).
* Fixed a typo in the configuration file, changing `"base_domain": "https://exemple.org"` to `"base_domain": "https://example.org"` in `config.json`.

Logging improvements:
* Removed redundant `print` statements for final metrics in `predict_frame`, relying solely on logging for output (`src/pipeline_gemma.py`).

Code comment and parameter consistency:
* Updated commented-out code to use `system_message_internal` instead of `system_message` for consistency with the function signature (`src/pipeline_gemma.py`).
* Cleaned up commented code formatting for clarity in `predict_frame` (`src/pipeline_gemma.py`).