### PR TITLE
feat: add file upload configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import Flask
 from flask import request, jsonify, g
 from werkzeug.utils import secure_filename
 
+from config import Config
 from src.service.generate_profile_service import load_classifier
 from src.service.file_upload_service import UPLOAD_FOLDER, allowed_file
 from src.service.generate_profile_service import generate_profile_service_store, generate_profile_service
@@ -180,11 +181,16 @@ async def rdf_profile():
               type: object
       400:
         description: Bad request (missing file or invalid parameters)
+      403:
+        description: Permission denied
       429:
         description: Too many active requests
       500:
         description: Server overloaded or internal error
     """
+    if not Config.ALLOW_UPLOAD:
+        app.logger.error(f"Profile generation returned an error: No permission to upload file")  # Log the error details
+        return jsonify({"error": "No permission to upload file"}), 403
     if 'file' not in request.files:
         return jsonify({"error": "No file part"}), 400
 

--- a/config.json
+++ b/config.json
@@ -31,6 +31,7 @@
   "general_settings": {
     "info": "Possible classifiers: SVM, NAIVE_BAYES, KNN, J48, MISTRAL, MLP, DEEP, BATCHNORM, Phase: LABELING, EXTRACTION, PROCESSING, TRAINING, STORE",
     "start_phase": "labeling",
-    "stop_phase": "training"
+    "stop_phase": "training",
+    "allow_upload": "false"
   }
 }

--- a/config.json
+++ b/config.json
@@ -32,6 +32,6 @@
     "info": "Possible classifiers: SVM, NAIVE_BAYES, KNN, J48, MISTRAL, MLP, DEEP, BATCHNORM, Phase: LABELING, EXTRACTION, PROCESSING, TRAINING, STORE",
     "start_phase": "labeling",
     "stop_phase": "training",
-    "allow_upload": "false"
+    "allow_upload": false
   }
 }

--- a/config.py
+++ b/config.py
@@ -47,6 +47,7 @@ class Config:
     START_PHASE: Phase = Phase.TRAINING
     STOP_PHASE: Phase = Phase.TRAINING
     ALLOWED_PHASE: list[Phase] = [Phase.PROCESSING, Phase.TRAINING]
+    ALLOW_UPLOAD: bool = False
 
     @staticmethod
     def init_configuration():
@@ -108,6 +109,7 @@ class Config:
         Config.STORE_PROFILE_AT_RUN = bool(config["profile"].get("store_profile_at_run", False))
         Config.BASE_DOMAIN = config["profile"].get("base_domain", "https://exemple.org")
 
+        Config.ALLOW_UPLOAD = bool(config["general_settings"].get("allow_upload", False))
         Config.START_PHASE = _assign_enum_phase(config["general_settings"].get("start_phase", "NO"))
         Config.STOP_PHASE = _assign_enum_phase(config["general_settings"].get("stop_phase", "NO"))
         _check_phase_order(Config.START_PHASE, Config.STOP_PHASE)

--- a/frontend/kgsum-frontend/src/app/classify/form.tsx
+++ b/frontend/kgsum-frontend/src/app/classify/form.tsx
@@ -10,7 +10,7 @@ import {Checkbox} from "@/components/ui/checkbox";
 import {Button} from "@/components/ui/button";
 import {Textarea} from "@/components/ui/textarea";
 import Link from "next/link";
-const UPLOAD =  process.env.UPLOAD === 'true' || false
+const UPLOAD = process.env.UPLOAD === 'true';
 
 function FileIcon(props: React.SVGProps<SVGSVGElement>) {
     return (

--- a/frontend/kgsum-frontend/src/app/classify/form.tsx
+++ b/frontend/kgsum-frontend/src/app/classify/form.tsx
@@ -10,6 +10,7 @@ import {Checkbox} from "@/components/ui/checkbox";
 import {Button} from "@/components/ui/button";
 import {Textarea} from "@/components/ui/textarea";
 import Link from "next/link";
+const UPLOAD =  process.env.UPLOAD === 'true' || false
 
 function FileIcon(props: React.SVGProps<SVGSVGElement>) {
     return (
@@ -241,7 +242,11 @@ export const Form = () => {
 
     // Reset form when switching tabs
     const handleTabChange = (newTab: string) => {
-        setTab(newTab as "SPARQL" | "DUMP");
+        if (UPLOAD) {
+            setTab(newTab as "SPARQL" | "DUMP");
+        } else {
+            setTab(newTab as "SPARQL");
+        }
         // Reset form state when switching tabs
         setSparqlUrl("");
         setHasFile(false);
@@ -278,14 +283,19 @@ export const Form = () => {
                                     className="w-full"
                                 >
                                     <div className="flex justify-center mb-6">
-                                        <TabsList className="grid w-full max-w-md grid-cols-2 h-10">
+                                        {UPLOAD? <TabsList className="grid w-full max-w-md grid-cols-2 h-10">
                                             <TabsTrigger value="SPARQL" id="tab-sparql" className="text-center text-sm">
                                                 SPARQL
                                             </TabsTrigger>
                                             <TabsTrigger value="DUMP" id="tab-dump" className="text-center text-sm">
                                                 DUMP
                                             </TabsTrigger>
+                                        </TabsList> : <TabsList className="grid w-full max-w-md grid-cols-1 h-10">
+                                            <TabsTrigger value="SPARQL" id="tab-sparql" className="text-center text-sm">
+                                                SPARQL
+                                            </TabsTrigger>
                                         </TabsList>
+                                        }
                                     </div>
 
                                     {/* Fixed height container for consistent tab content height */}
@@ -313,7 +323,7 @@ export const Form = () => {
                                             </div>
                                         </TabsContent>
 
-                                        <TabsContent value="DUMP" className="space-y-4 mt-0">
+                                        {UPLOAD && <TabsContent value="DUMP" className="space-y-4 mt-0">
                                             <Card
                                                 className="border-2 border-dashed border-muted hover:border-muted-foreground/50 transition-colors min-h-[180px]">
                                                 <CardContent
@@ -397,7 +407,7 @@ export const Form = () => {
                                                     </p>
                                                 </div>
                                             )}
-                                        </TabsContent>
+                                        </TabsContent> }
                                     </div>
                                 </Tabs>
                             </div>

--- a/frontend/kgsum-frontend/src/app/classify/form.tsx
+++ b/frontend/kgsum-frontend/src/app/classify/form.tsx
@@ -283,7 +283,7 @@ export const Form = () => {
                                     className="w-full"
                                 >
                                     <div className="flex justify-center mb-6">
-                                        {UPLOAD? <TabsList className="grid w-full max-w-md grid-cols-2 h-10">
+                                        {UPLOAD ? <TabsList className="grid w-full max-w-md grid-cols-2 h-10">
                                             <TabsTrigger value="SPARQL" id="tab-sparql" className="text-center text-sm">
                                                 SPARQL
                                             </TabsTrigger>


### PR DESCRIPTION
This pull request introduces a configurable permission system for file uploads in both the backend and frontend, allowing the feature to be toggled via configuration. The backend now checks the `ALLOW_UPLOAD` flag before permitting uploads, and the frontend dynamically adjusts its UI based on the upload permission, hiding or showing file upload options accordingly.

**Backend: File Upload Permission Enforcement**
* Added a new `ALLOW_UPLOAD` boolean flag to the `Config` class, initialized from the `allow_upload` setting in `config.json` during configuration setup. [[1]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R50) [[2]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R112) [[3]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL34-R35)
* Updated the `rdf_profile` endpoint in `app.py` to return a 403 error if `ALLOW_UPLOAD` is `False`, preventing unauthorized file uploads.
* Imported `Config` in `app.py` to access the new configuration flag.

**Frontend: Dynamic UI Based on Upload Permission**
* Introduced an `UPLOAD` constant, derived from an environment variable, to control the visibility of the file upload (DUMP) tab in the classification form.
* Modified tab switching logic and tab rendering in `form.tsx` to conditionally display the DUMP tab and its content only when uploads are allowed. [[1]](diffhunk://#diff-c48b32a6686d610c5ba04aaed88721a7174fbcbf2c1d360bd51e2da9d72d4fbcR245-R249) [[2]](diffhunk://#diff-c48b32a6686d610c5ba04aaed88721a7174fbcbf2c1d360bd51e2da9d72d4fbcL281-R298) [[3]](diffhunk://#diff-c48b32a6686d610c5ba04aaed88721a7174fbcbf2c1d360bd51e2da9d72d4fbcL316-R326) [[4]](diffhunk://#diff-c48b32a6686d610c5ba04aaed88721a7174fbcbf2c1d360bd51e2da9d72d4fbcL400-R410)