### PR TITLE
documentation: correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,13 @@ Configure the backend by editing `config.json`:
   },
   "profile": {
     "store_profile_after_training": false,
-    "base_domain": "https://exemple.org"
+    "base_domain": "https://example.org"
   },
-  "general_setting": {
+  "general_settings": {
     "info": "Possible classifiers: SVM, NAIVE_BAYES, KNN, J48, MISTRAL, MLP, DEEP, BATCHNORM, Phase: LABELING, EXTRACTION, PROCESSING, TRAINING, STORE",
     "start_phase": "labeling",
-    "stop_phase": "training"
+    "stop_phase": "training",
+    "allow_upload": "false"
   }
 }
 ```


### PR DESCRIPTION
This pull request updates the backend configuration instructions in the `README.md` to fix naming inconsistencies and clarify settings. The most important changes are grouped below:

Configuration consistency and clarity:

* Renamed the `general_setting` section to `general_settings` for consistency with the rest of the configuration.
* Corrected the `base_domain` value from `https://exemple.org` to the proper spelling, `https://example.org`.
* Added a new `allow_upload` setting to the `general_settings` section, defaulting to `"false"`, to control upload permissions.